### PR TITLE
PigTimer

### DIFF
--- a/EQTool/Services/Parsing/InvisParser.cs
+++ b/EQTool/Services/Parsing/InvisParser.cs
@@ -1,6 +1,5 @@
 ﻿using EQTool.Models;
 using System;
-using System.Media;
 using System.Text.RegularExpressions;
 
 
@@ -26,11 +25,6 @@ namespace EQTool.Services.Parsing
             if (m != null)
             {
                 logEvents.Handle(new InvisEvent { InvisStatus = m.Value });
-
-                //// just a little audible marker to help us debug and test
-                //System.Media.SoundPlayer player = new System.Media.SoundPlayer(@"c:\Windows\Media\chimes.wav");
-                //player.Play();
-
                 return true;
             }
             return false;

--- a/EQTool/Services/Parsing/LogStartCustomTimer.cs
+++ b/EQTool/Services/Parsing/LogStartCustomTimer.cs
@@ -1,24 +1,53 @@
 ﻿using EQTool.Models;
 using EQToolShared.HubModels;
 using System;
+using System.Diagnostics.Eventing.Reader;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows.Shapes;
 
 namespace EQTool.Services.Parsing
 {
+    //
+    // Class to parse for a custom timer, in the form of one of the following:
+    //      .ct-duration
+    //      .ct-duration-label
+    // where
+    //      .ct (short of Custom Timer) is the identifying marker
+    //      duration can be in formats:
+    //          hh:mm:ss
+    //          mm:ss
+    //          ss
+    //      content can be in a tell, or in a visible channel, like /say
+    //      Note: there cannot be any blank spaces
+    //
+    // Examples:
+    //      .ct-30                      30 second timer, with no name
+    //      .ct-10                      10 second timer, with no name
+    //      .ct-10:00                   10 minute timer, with no name
+    //      .ct-10:00:00                10 hour timer, with no name
+    //      .ct-120-description         120 second timer, with name 'description'
+    //      .ct-6:40-Tim_the_Mighty     6 minutes 40 second timer, with name 'Tim_the_Mighty'
+    //      .ct-1:02:00-LongTimer       1 hour, 2 minute timer, with description 'LongTimer'
+    //
     public class LogStartCustomTimer : IEqLogParseHandler
     {
-        private readonly string StartTimer = "you say, 'timer start";
-        private readonly string StartTimer1 = "you say, 'start timer";
-
         private readonly LogEvents logEvents;
+
+        //
+        // ctor
+        //
         public LogStartCustomTimer(LogEvents logEvents)
         {
             this.logEvents = logEvents;
         }
 
+        //
+        // overload the Handle method to perform the specific parsing
+        //
         public bool Handle(string line, DateTime timestamp)
         {
-            var m = GetStartTimer(line);
+            var m = ParseStartTimer(line, timestamp);
             if (m != null)
             {
                 logEvents.Handle(new StartTimerEvent { CustomTimer = m });
@@ -27,61 +56,70 @@ namespace EQTool.Services.Parsing
             return false;
         }
 
-        public CustomTimer GetStartTimer(string message)
+        //
+        // parse the passed line to see if user has requested a custom timer to started
+        //
+        public CustomTimer ParseStartTimer(string line, DateTime timestamp)
         {
-            var timer = GetStartTimer(message, StartTimer);
-            if (timer != null)
-            {
-                return timer;
-            }
-            else
-            {
-                timer = GetStartTimer(message, StartTimer1);
-            }
+            // return value
+            CustomTimer rv = null;
 
-            return timer;
-        }
-
-        private static CustomTimer GetStartTimer(string message, string messagetolookfor)
-        {
-            if (message.ToLower().StartsWith(messagetolookfor))
+            // set up a crazy regex to watch for formats like
+            //      .ct-30                  30 second timer, with no name
+            //      .ct-120-description     120 second timer, with name 'description'
+            //      .ct-6:40-Guard          6 minutes 40 second timer, with name 'Guard'
+            //      .ct-10:00               10 minute timer, with no name
+            //      .ct-1:02:00-LongTimer   1 hour, 2 minute timer, with description 'LongTimer'
+            string customTimerPattern = @"\.ct-(((?<hh>[0-9]+):)?((?<mm>[0-9]+):))?(?<ss>[0-9]+)(-(?<label>\w+))*";
+            //                            \.ct-                                                                         must start with .ct-
+            //                                  ((?<hh>[0-9]+):)?                                                       Group "hh"      0 or more (sets of numbers, followed by a colon)
+            //                                                   ((?<mm>[0-9]+):)                                       Group "mm"      (set of numbers followed by a colon)
+            //                                 (                                 )?                                                     0 or more hh and mm groups
+            //                                                                     (?<ss>[0-9]+)                        Group "ss"      1 set of numbers
+            //                                                                                  (-(?<label>\w+))*       Group "label"   0 or more (dash, followed by a set of word characters)
+            //
+            // This website is absolutely needed when creating this kind of crazy regex!
+            //      https://regex101.com/r/RWA9Oy/1
+            Regex regex = new Regex(customTimerPattern, RegexOptions.Compiled);
+            var match = regex.Match(line);
+            if (match.Success)
             {
-                var removedstartimer = message.ToLower().Replace(messagetolookfor, string.Empty).Trim();
-                if (removedstartimer.Contains(":"))
+                // just a little audible marker
+                System.Media.SoundPlayer player = new System.Media.SoundPlayer(@"c:\Windows\Media\chimes.wav");
+                player.Play();
+
+                // get results from the rexex scan
+                var hh = match.Groups["hh"].Value;
+                var mm = match.Groups["mm"].Value;
+                var ss = match.Groups["ss"].Value;
+                var label = match.Groups["label"].Value;
+
+                // count up the seconds
+                int timerSeconds = 0;
+                if (ss != "")
                 {
-                    var numbersonly = new string(removedstartimer.Where(a => char.IsDigit(a) || a == ':').ToArray());
-                    if (int.TryParse(numbersonly.Split(':')[0], out var minutes) && int.TryParse(numbersonly.Split(':')[1], out var seconds))
-                    {
-                        var firstnumber = removedstartimer.IndexOfAny(new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' });
-                        if (firstnumber != -1)
-                        {
-                            var nameasstring = removedstartimer.Substring(0, firstnumber).Trim();
-                            var ts = new TimeSpan(0, minutes, seconds);
-                            return new CustomTimer
-                            {
-                                Name = nameasstring,
-                                DurationInSeconds = (int)ts.TotalSeconds
-                            };
-                        }
-                    }
+                    timerSeconds += int.Parse(ss);
                 }
+                if (mm != "")
+                {
+                    timerSeconds += 60 * int.Parse(mm);
+                }
+                if (hh != "")
+                {
+                    timerSeconds += 3600 * int.Parse(hh);
+                }
+                Console.WriteLine($"match found [{match}], [{hh}], [{mm}], [{ss}], [{label}], [{timerSeconds}]");
+
+                // return value
+                rv = new CustomTimer();
+                rv.DurationInSeconds = timerSeconds;
+                // if the user didn't specify a label, we'll give it the timestamp of this line
+                if (label != "")
+                    rv.Name = label;
                 else
-                {
-                    var numbersonly = new string(removedstartimer.Where(a => char.IsDigit(a)).ToArray());
-                    if (int.TryParse(numbersonly, out var minutesint))
-                    {
-                        var nameasstring = minutesint.ToString();
-                        var name = removedstartimer.Replace(nameasstring, string.Empty).Trim('\'').Trim();
-                        return new CustomTimer
-                        {
-                            Name = name,
-                            DurationInSeconds = minutesint * 60
-                        };
-                    }
-                }
+                    rv.Name = timestamp.ToString();
             }
-
-            return null;
+            return rv;
         }
     }
 }

--- a/EQTool/Services/Parsing/LogStartCustomTimer.cs
+++ b/EQTool/Services/Parsing/LogStartCustomTimer.cs
@@ -11,9 +11,9 @@ namespace EQTool.Services.Parsing
     //
     // Class to parse for a custom timer, in the form of one of the following:
     //      .ct-duration
-    //      .ct-duration-label
+    //      PigTimer-duration-label
     // where
-    //      .ct (short of Custom Timer) is the identifying marker
+    //      PigTimer (short of Custom Timer) is the identifying marker
     //      duration can be in formats:
     //          hh:mm:ss
     //          mm:ss
@@ -22,13 +22,13 @@ namespace EQTool.Services.Parsing
     //      Note: there cannot be any blank spaces
     //
     // Examples:
-    //      .ct-30                      30 second timer, with no name
-    //      .ct-10                      10 second timer, with no name
-    //      .ct-10:00                   10 minute timer, with no name
-    //      .ct-10:00:00                10 hour timer, with no name
-    //      .ct-120-description         120 second timer, with name 'description'
-    //      .ct-6:40-Tim_the_Mighty     6 minutes 40 second timer, with name 'Tim_the_Mighty'
-    //      .ct-1:02:00-LongTimer       1 hour, 2 minute timer, with description 'LongTimer'
+    //      PigTimer-30                      30 second timer, with no name
+    //      PigTimer-10                      10 second timer, with no name
+    //      PigTimer-10:00                   10 minute timer, with no name
+    //      PigTimer-10:00:00                10 hour timer, with no name
+    //      PigTimer-120-description         120 second timer, with name 'description'
+    //      PigTimer-6:40-Tim_the_Mighty     6 minutes 40 second timer, with name 'Tim_the_Mighty'
+    //      PigTimer-1:02:00-LongTimer       1 hour, 2 minute timer, with description 'LongTimer'
     //
     public class LogStartCustomTimer : IEqLogParseHandler
     {
@@ -65,18 +65,18 @@ namespace EQTool.Services.Parsing
             CustomTimer rv = null;
 
             // set up a crazy regex to watch for formats like
-            //      .ct-30                  30 second timer, with no name
-            //      .ct-120-description     120 second timer, with name 'description'
-            //      .ct-6:40-Guard          6 minutes 40 second timer, with name 'Guard'
-            //      .ct-10:00               10 minute timer, with no name
-            //      .ct-1:02:00-LongTimer   1 hour, 2 minute timer, with description 'LongTimer'
-            string customTimerPattern = @"\.ct-(((?<hh>[0-9]+):)?((?<mm>[0-9]+):))?(?<ss>[0-9]+)(-(?<label>\w+))*";
-            //                            \.ct-                                                                         must start with .ct-
-            //                                  ((?<hh>[0-9]+):)?                                                       Group "hh"      0 or more (sets of numbers, followed by a colon)
-            //                                                   ((?<mm>[0-9]+):)                                       Group "mm"      (set of numbers followed by a colon)
-            //                                 (                                 )?                                                     0 or more hh and mm groups
-            //                                                                     (?<ss>[0-9]+)                        Group "ss"      1 set of numbers
-            //                                                                                  (-(?<label>\w+))*       Group "label"   0 or more (dash, followed by a set of word characters)
+            //      PigTimer-30                  30 second timer, with no name
+            //      PigTimer-120-description     120 second timer, with name 'description'
+            //      PigTimer-6:40-Guard          6 minutes 40 second timer, with name 'Guard'
+            //      PigTimer-10:00               10 minute timer, with no name
+            //      PigTimer-1:02:00-LongTimer   1 hour, 2 minute timer, with description 'LongTimer'
+            string customTimerPattern = @"PigTimer-(((?<hh>[0-9]+):)?((?<mm>[0-9]+):))?(?<ss>[0-9]+)(-(?<label>\w+))*";
+            //                            PigTimer-                                                                         must start with PigTimer-
+            //                                      ((?<hh>[0-9]+):)?                                                       Group "hh"      0 or more (sets of numbers, followed by a colon)
+            //                                                       ((?<mm>[0-9]+):)                                       Group "mm"      1 set of numbers followed by a colon
+            //                                     (                                 )?                                                     0 or more hh and mm groups
+            //                                                                         (?<ss>[0-9]+)                        Group "ss"      1 set of numbers
+            //                                                                                      (-(?<label>\w+))*       Group "label"   0 or more (dash, followed by a set of word characters)
             //
             // This website is absolutely needed when creating this kind of crazy regex!
             //      https://regex101.com/r/RWA9Oy/1

--- a/EQTool/Services/Parsing/LogStartCustomTimer.cs
+++ b/EQTool/Services/Parsing/LogStartCustomTimer.cs
@@ -47,7 +47,7 @@ namespace EQTool.Services.Parsing
         //
         public bool Handle(string line, DateTime timestamp)
         {
-            var m = ParseStartTimer(line, timestamp);
+            var m = ParseStartTimer(line);
             if (m != null)
             {
                 logEvents.Handle(new StartTimerEvent { CustomTimer = m });
@@ -59,7 +59,7 @@ namespace EQTool.Services.Parsing
         //
         // parse the passed line to see if user has requested a custom timer to started
         //
-        public CustomTimer ParseStartTimer(string line, DateTime timestamp)
+        public CustomTimer ParseStartTimer(string line)
         {
             // return value
             CustomTimer rv = null;
@@ -113,11 +113,11 @@ namespace EQTool.Services.Parsing
                 // return value
                 rv = new CustomTimer();
                 rv.DurationInSeconds = timerSeconds;
-                // if the user didn't specify a label, we'll give it the timestamp of this line
+                // if the user didn't specify a label, we'll give it the match string
                 if (label != "")
                     rv.Name = label;
                 else
-                    rv.Name = timestamp.ToString();
+                    rv.Name = $"{match}";
             }
             return rv;
         }

--- a/EQtoolsTests/SpellTests.cs
+++ b/EQtoolsTests/SpellTests.cs
@@ -1205,7 +1205,7 @@ namespace EQToolTests
         public void GetCustomTimerStart()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, '.ct-30:00-StupidGoblin'";
+            var line = "You say, 'PigTimer-30:00-StupidGoblin'";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1217,7 +1217,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_WithSeconds()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, '.ct-30:20-StupidGoblin'";
+            var line = "You say, 'PigTimer-30:20-StupidGoblin'";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1229,7 +1229,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_WithSeconds_andmorethan60minutes()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, '.ct-90:20-StupidGoblin'";
+            var line = "You say, 'PigTimer-90:20-StupidGoblin'";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1241,7 +1241,7 @@ namespace EQToolTests
         public void GetCustomTimerStart1()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, '.ct-30:00-StupidGoblin'";
+            var line = "You say, 'PigTimer-30:00-StupidGoblin'";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1253,7 +1253,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_TestSpaces()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, '.ct-30:00-StupidGoblin_with_club_near_me'";
+            var line = "You say, 'PigTimer-30:00-StupidGoblin_with_club_near_me'";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1265,7 +1265,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_Test1()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = ".ct-02";
+            var line = "PigTimer-02";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1277,7 +1277,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_Test2()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = ".ct-02:03";
+            var line = "PigTimer-02:03";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1289,7 +1289,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_Test3()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = ".ct-02:03:04";
+            var line = "PigTimer-02:03:04";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1301,7 +1301,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_Test1a()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = ".ct-02-xyzzy";
+            var line = "PigTimer-02-xyzzy";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1313,7 +1313,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_Test2a()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = ".ct-02:03-xyzzy";
+            var line = "PigTimer-02:03-xyzzy";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
@@ -1325,7 +1325,7 @@ namespace EQToolTests
         public void GetCustomTimerStart_Test3a()
         {
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = ".ct-02:03:04-xyzzy";
+            var line = "PigTimer-02:03:04-xyzzy";
             var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);

--- a/EQtoolsTests/SpellTests.cs
+++ b/EQtoolsTests/SpellTests.cs
@@ -1204,10 +1204,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = "You say, '.ct-30:00-StupidGoblin'";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(30 * 60, targettoremove.DurationInSeconds);
@@ -1217,10 +1216,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart_WithSeconds()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = "You say, '.ct-30:20-StupidGoblin'";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual((30 * 60) + 20, targettoremove.DurationInSeconds);
@@ -1230,10 +1228,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart_WithSeconds_andmorethan60minutes()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = "You say, '.ct-90:20-StupidGoblin'";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual((90 * 60) + 20, targettoremove.DurationInSeconds);
@@ -1243,10 +1240,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart1()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = "You say, '.ct-30:00-StupidGoblin'";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(30 * 60, targettoremove.DurationInSeconds);
@@ -1256,10 +1252,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart_TestSpaces()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = "You say, '.ct-30:00-StupidGoblin_with_club_near_me'";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(30 * 60, targettoremove.DurationInSeconds);
@@ -1269,49 +1264,45 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart_Test1()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = ".ct-02";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(2, targettoremove.DurationInSeconds);
-            Assert.AreEqual(dt.ToString(), targettoremove.Name);
+            Assert.AreEqual(line, targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart_Test2()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = ".ct-02:03";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(2*60+3, targettoremove.DurationInSeconds);
-            Assert.AreEqual(dt.ToString(), targettoremove.Name);
+            Assert.AreEqual(line, targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart_Test3()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = ".ct-02:03:04";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(2 * 3600 + 3*60 + 4, targettoremove.DurationInSeconds);
-            Assert.AreEqual(dt.ToString(), targettoremove.Name);
+            Assert.AreEqual(line, targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart_Test1a()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = ".ct-02-xyzzy";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(2, targettoremove.DurationInSeconds);
@@ -1321,10 +1312,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart_Test2a()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = ".ct-02:03-xyzzy";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(2 * 60 + 3, targettoremove.DurationInSeconds);
@@ -1334,10 +1324,9 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart_Test3a()
         {
-            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
             var line = ".ct-02:03:04-xyzzy";
-            var targettoremove = service.ParseStartTimer(line, dt);
+            var targettoremove = service.ParseStartTimer(line);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(2 * 3600 + 3 * 60 + 4, targettoremove.DurationInSeconds);

--- a/EQtoolsTests/SpellTests.cs
+++ b/EQtoolsTests/SpellTests.cs
@@ -1204,61 +1204,144 @@ namespace EQToolTests
         [TestMethod]
         public void GetCustomTimerStart()
         {
+            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, 'Timer Start StupidGoblin 30'";
-            var targettoremove = service.GetStartTimer(line);
+            var line = "You say, '.ct-30:00-StupidGoblin'";
+            var targettoremove = service.ParseStartTimer(line, dt);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(30 * 60, targettoremove.DurationInSeconds);
-            Assert.AreEqual("stupidgoblin", targettoremove.Name);
+            Assert.AreEqual("StupidGoblin", targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart_WithSeconds()
         {
+            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, 'Timer Start StupidGoblin 30:20'";
-            var targettoremove = service.GetStartTimer(line);
+            var line = "You say, '.ct-30:20-StupidGoblin'";
+            var targettoremove = service.ParseStartTimer(line, dt);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual((30 * 60) + 20, targettoremove.DurationInSeconds);
-            Assert.AreEqual("stupidgoblin", targettoremove.Name);
+            Assert.AreEqual("StupidGoblin", targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart_WithSeconds_andmorethan60minutes()
         {
+            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, 'Timer Start StupidGoblin 90:20'";
-            var targettoremove = service.GetStartTimer(line);
+            var line = "You say, '.ct-90:20-StupidGoblin'";
+            var targettoremove = service.ParseStartTimer(line, dt);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual((90 * 60) + 20, targettoremove.DurationInSeconds);
-            Assert.AreEqual("stupidgoblin", targettoremove.Name);
+            Assert.AreEqual("StupidGoblin", targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart1()
         {
+            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, 'Start Timer StupidGoblin 30'";
-            var targettoremove = service.GetStartTimer(line);
+            var line = "You say, '.ct-30:00-StupidGoblin'";
+            var targettoremove = service.ParseStartTimer(line, dt);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(30 * 60, targettoremove.DurationInSeconds);
-            Assert.AreEqual("stupidgoblin", targettoremove.Name);
+            Assert.AreEqual("StupidGoblin", targettoremove.Name);
         }
 
         [TestMethod]
         public void GetCustomTimerStart_TestSpaces()
         {
+            DateTime dt = DateTime.Now;
             var service = container.Resolve<LogStartCustomTimer>();
-            var line = "You say, 'Start Timer StupidGoblin with club near me 30'";
-            var targettoremove = service.GetStartTimer(line);
+            var line = "You say, '.ct-30:00-StupidGoblin_with_club_near_me'";
+            var targettoremove = service.ParseStartTimer(line, dt);
 
             Assert.IsNotNull(targettoremove);
             Assert.AreEqual(30 * 60, targettoremove.DurationInSeconds);
-            Assert.AreEqual("stupidgoblin with club near me", targettoremove.Name);
+            Assert.AreEqual("StupidGoblin_with_club_near_me", targettoremove.Name);
+        }
+
+        [TestMethod]
+        public void GetCustomTimerStart_Test1()
+        {
+            DateTime dt = DateTime.Now;
+            var service = container.Resolve<LogStartCustomTimer>();
+            var line = ".ct-02";
+            var targettoremove = service.ParseStartTimer(line, dt);
+
+            Assert.IsNotNull(targettoremove);
+            Assert.AreEqual(2, targettoremove.DurationInSeconds);
+            Assert.AreEqual(dt.ToString(), targettoremove.Name);
+        }
+
+        [TestMethod]
+        public void GetCustomTimerStart_Test2()
+        {
+            DateTime dt = DateTime.Now;
+            var service = container.Resolve<LogStartCustomTimer>();
+            var line = ".ct-02:03";
+            var targettoremove = service.ParseStartTimer(line, dt);
+
+            Assert.IsNotNull(targettoremove);
+            Assert.AreEqual(2*60+3, targettoremove.DurationInSeconds);
+            Assert.AreEqual(dt.ToString(), targettoremove.Name);
+        }
+
+        [TestMethod]
+        public void GetCustomTimerStart_Test3()
+        {
+            DateTime dt = DateTime.Now;
+            var service = container.Resolve<LogStartCustomTimer>();
+            var line = ".ct-02:03:04";
+            var targettoremove = service.ParseStartTimer(line, dt);
+
+            Assert.IsNotNull(targettoremove);
+            Assert.AreEqual(2 * 3600 + 3*60 + 4, targettoremove.DurationInSeconds);
+            Assert.AreEqual(dt.ToString(), targettoremove.Name);
+        }
+
+        [TestMethod]
+        public void GetCustomTimerStart_Test1a()
+        {
+            DateTime dt = DateTime.Now;
+            var service = container.Resolve<LogStartCustomTimer>();
+            var line = ".ct-02-xyzzy";
+            var targettoremove = service.ParseStartTimer(line, dt);
+
+            Assert.IsNotNull(targettoremove);
+            Assert.AreEqual(2, targettoremove.DurationInSeconds);
+            Assert.AreEqual("xyzzy", targettoremove.Name);
+        }
+
+        [TestMethod]
+        public void GetCustomTimerStart_Test2a()
+        {
+            DateTime dt = DateTime.Now;
+            var service = container.Resolve<LogStartCustomTimer>();
+            var line = ".ct-02:03-xyzzy";
+            var targettoremove = service.ParseStartTimer(line, dt);
+
+            Assert.IsNotNull(targettoremove);
+            Assert.AreEqual(2 * 60 + 3, targettoremove.DurationInSeconds);
+            Assert.AreEqual("xyzzy", targettoremove.Name);
+        }
+
+        [TestMethod]
+        public void GetCustomTimerStart_Test3a()
+        {
+            DateTime dt = DateTime.Now;
+            var service = container.Resolve<LogStartCustomTimer>();
+            var line = ".ct-02:03:04-xyzzy";
+            var targettoremove = service.ParseStartTimer(line, dt);
+
+            Assert.IsNotNull(targettoremove);
+            Assert.AreEqual(2 * 3600 + 3 * 60 + 4, targettoremove.DurationInSeconds);
+            Assert.AreEqual("xyzzy", targettoremove.Name);
         }
 
         [TestMethod]
@@ -1355,7 +1438,7 @@ namespace EQToolTests
         {
             var line = "Sat Oct 08 11:31:38 2022";
             var d = LogFileDateTimeParse.ParseDateTime(line);
-            Assert.AreEqual(d.ToString(), "10/8/2022 11:31:38 AM");
+            Assert.AreEqual(d.ToString("M'/'d'/'yyyy hh:mm:ss tt"), "10/8/2022 11:31:38 AM");
         }
 
         [TestMethod]

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Features:
   <li>Hanbox shouts, 'RAMP2 CH --Beefwich'</li>
   <li>Hanbox shouts, 'CH - name - 001'</li> 
 </ul>
-<h4>Timers -- All below commands work in tells (keep them private!) or regular say (share with your friends!)</h4>
+<h3>Timers</h3>
 <ul>
+All below commands work in tells (keep them private!) or regular say (share with your friends!)
 
       /t .ct-duration
       /t .ct-duration-label
@@ -85,23 +86,24 @@ Features:
       /say .ct-duration-label
  where
  
-      .ct (short for Custom Timer) is the identifying marker
-      .ct, duration, and label should be separated by a - dash
-      duration can be in various formats, e.g.:
+      ".ct" (short for Custom Timer) is the identifying marker
+      "duration" can be in time formats:
            hh:mm:ss
            mm:ss
            seconds
+      "label" can contain any character, number, or underscore, but cannot have blank spaces
 
-      The timer start phrase can be in a tell (that only you will see), or in any visible channel (which others see)
-      Note: there cannot be any blank spaces!!
+      ".ct", "duration", and "label" should be separated by a - dash
+
+  This can be in a tell (that only you will see), or in any visible channel (which others see).
 
 
 Examples:
 
       .ct-30                      30 second timer, with no label
-      .ct-10-Ten_Seconds          10 second timer, with label
-      .ct-10:00-Ten_Minutes       10 minute timer, with label
-      .ct-10:00:00-Ten_Hours      10 hour timer, with label
+      .ct-10-TenSeconds           10 second timer, with label
+      .ct-10:00-TenMinutes        10 minute timer, with label
+      .ct-10:00:00-TenHours       10 hour timer, with label
       .ct-120-description         120 second timer, with label 'description'
       .ct-6:40-Guard_George       6 minutes 40 second timer, with label 'Guard_George'
       .ct-1:02:00-LongTimer       1 hour, 2 minute timer, with label 'LongTimer'

--- a/README.md
+++ b/README.md
@@ -74,12 +74,38 @@ Features:
   <li>Hanbox shouts, 'RAMP2 CH --Beefwich'</li>
   <li>Hanbox shouts, 'CH - name - 001'</li> 
 </ul>
-<h5>Timers (Only Minutes are supported) -- All below commands work in regular say!</h5>
+<h4>Timers -- All below commands work in tells (keep them private!) or regular say (share with your friends!)</h4>
 <ul>
-<li>Timer Start Crypt Camp 35</li>
-<li>Start Timer Crypt Camp 35</li>
-<li>Timer Cancel Crypt Camp</li>
-<li>Cancel Timer Crypt Camp</li>
+
+      /t .ct-duration
+      /t .ct-duration-label
+ or 
+
+      /say .ct-duration
+      /say .ct-duration-label
+ where
+ 
+      .ct (short for Custom Timer) is the identifying marker
+      .ct, duration, and label should be separated by a - dash
+      duration can be in various formats, e.g.:
+           hh:mm:ss
+           mm:ss
+           seconds
+
+      The timer start phrase can be in a tell (that only you will see), or in any visible channel (which others see)
+      Note: there cannot be any blank spaces!!
+
+
+Examples:
+
+      .ct-30                      30 second timer, with no label
+      .ct-10-Ten_Seconds          10 second timer, with label
+      .ct-10:00-Ten_Minutes       10 minute timer, with label
+      .ct-10:00:00-Ten_Hours      10 hour timer, with label
+      .ct-120-description         120 second timer, with label 'description'
+      .ct-6:40-Guard_George       6 minutes 40 second timer, with label 'Guard_George'
+      .ct-1:02:00-LongTimer       1 hour, 2 minute timer, with label 'LongTimer'
+
 </ul>
 <img width="1624" alt="image" src="https://github.com/smasherprog/EqTool/assets/3393733/3c53a1d8-44c4-499b-9e92-ea5d5f38275e">
 <h4>CH Chain overlay Below</h4>

--- a/README.md
+++ b/README.md
@@ -78,35 +78,35 @@ Features:
 <ul>
 All below commands work in tells (keep them private!) or regular say (share with your friends!)
 
-      /t .ct-duration
-      /t .ct-duration-label
+      /t PigTimer-duration
+      /t PigTimer-duration-label
  or 
 
-      /say .ct-duration
-      /say .ct-duration-label
+      /say PigTimer-duration
+      /say PigTimer-duration-label
  where
  
-      ".ct" (short for Custom Timer) is the identifying marker
+      "PigTimer" is the identifying marker
       "duration" can be in time formats:
            hh:mm:ss
            mm:ss
            seconds
       "label" can contain any character, number, or underscore, but cannot have blank spaces
 
-      ".ct", "duration", and "label" should be separated by a - dash
+      "PigTimer", "duration", and "label" should be separated by a - dash
 
   This can be in a tell (that only you will see), or in any visible channel (which others see).
 
 
 Examples:
 
-      .ct-30                      30 second timer, with no label
-      .ct-10-TenSeconds           10 second timer, with label
-      .ct-10:00-TenMinutes        10 minute timer, with label
-      .ct-10:00:00-TenHours       10 hour timer, with label
-      .ct-120-description         120 second timer, with label 'description'
-      .ct-6:40-Guard_George       6 minutes 40 second timer, with label 'Guard_George'
-      .ct-1:02:00-LongTimer       1 hour, 2 minute timer, with label 'LongTimer'
+      PigTimer-30                      30 second timer, with no label
+      PigTimer-10-TenSeconds           10 second timer, with label
+      PigTimer-10:00-TenMinutes        10 minute timer, with label
+      PigTimer-10:00:00-TenHours       10 hour timer, with label
+      PigTimer-120-description         120 second timer, with label 'description'
+      PigTimer-6:40-Guard_George       6 minutes 40 second timer, with label 'Guard_George'
+      PigTimer-1:02:00-LongTimer       1 hour, 2 minute timer, with label 'LongTimer'
 
 </ul>
 <img width="1624" alt="image" src="https://github.com/smasherprog/EqTool/assets/3393733/3c53a1d8-44c4-499b-9e92-ea5d5f38275e">


### PR DESCRIPTION
Reworked the custom timer interface.

All below commands work in tells (keep them private!) or regular say (share with your friends!)

      /t PigTimer-duration
      /t PigTimer-duration-label
 or 
      /say PigTimer-duration
      /say PigTimer-duration-label

 where
 
      "PigTimer" is the identifying marker
      "duration" can be in time formats:
           hh:mm:ss
           mm:ss
           seconds
      "label" can contain any character, number, or underscore, but cannot have blank spaces

      "PigTimer", "duration", and "label" should be separated by a - dash

Examples:

      PigTimer-30                                30 second timer, with no label
      PigTimer-10-TenSeconds            10 second timer, with label
      PigTimer-10:00-TenMinutes        10 minute timer, with label
      PigTimer-10:00:00-TenHours       10 hour timer, with label
      PigTimer-120-description          120 second timer, with label 'description'
      PigTimer-6:40-Guard_George        6 minutes 40 second timer, with label 'Guard_George'
      PigTimer-1:02:00-LongTimer         1 hour, 2 minute timer, with label 'LongTimer'

The selection of "PigTimer" as the marker is in keeping with the whole PigParse theme, but is obviously somewhat arbitrary, and could be literally anything else.  It could also by synonym'd, like (PigTimer|.pt), for example.
