### PR TITLE
Improve GetCurrentDirectory lookups to actually use the Assembly's Directory

### DIFF
--- a/EQTool/App.xaml.cs
+++ b/EQTool/App.xaml.cs
@@ -163,14 +163,15 @@ namespace EQTool
 
         private bool ShouldShutDownDueToNoWriteAccess()
         {
+            var testFilePath = Path.Combine(KnownDirectories.GetExecutableDirectory(), "test.json");
             try
             {
-                File.Delete("test.json");
+                File.Delete(testFilePath);
             }
             catch { }
             try
             {
-                File.WriteAllText("test.json", "test");
+                File.WriteAllText(testFilePath, "test");
             }
             catch (UnauthorizedAccessException)
             {
@@ -179,10 +180,10 @@ namespace EQTool
             }
             try
             {
-                File.Delete("test.json");
+                File.Delete(testFilePath);
             }
             catch { }
-            var cwd = Directory.GetCurrentDirectory();
+            var cwd = KnownDirectories.GetExecutableDirectory();
             if (cwd.ToLower().Contains("program files"))
             {
                 _ = MessageBox.Show("Pigparse is running from a directory where it does not have permission to save settings. Please, move it to a folder where it can write!", "Pigparse Permissions!", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -209,7 +210,7 @@ namespace EQTool
             }
             try
             {
-                var curr = Directory.GetCurrentDirectory();
+                var curr = KnownDirectories.GetExecutableDirectory();
                 var path = Path.Combine(curr, "eqgame.exe");
                 if (File.Exists(path))
                 {

--- a/EQTool/EQTool.csproj
+++ b/EQTool/EQTool.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Services\Handlers\RandomRollHandler.cs" />
     <Compile Include="Services\Handlers\SpawnTimerHandler.cs" />
     <Compile Include="Services\Handlers\YourItemBeginsToGlowHandler.cs" />
+    <Compile Include="Services\KnownDirectories.cs" />
     <Compile Include="Services\Parsing\BeginsToCastTheGateSpellParser.cs" />
     <Compile Include="Services\Parsing\DisciplineCooldownParser.cs" />
     <Compile Include="Services\Parsing\ExpGainedParser.cs" />

--- a/EQTool/Services/EQToolSettingsLoad.cs
+++ b/EQTool/Services/EQToolSettingsLoad.cs
@@ -11,6 +11,7 @@ namespace EQTool.Services
 {
     public class EQToolSettingsLoad
     {
+        private static readonly string settingsFilePath = Path.Combine(KnownDirectories.GetExecutableDirectory(), "settings.json");
         private readonly FindEq findEq;
         private readonly LoggingService loggingService;
         private readonly object filelock = new object();
@@ -23,11 +24,11 @@ namespace EQTool.Services
 
         public EQToolSettings Load(int counter = 0)
         {
-            if (File.Exists("settings.json"))
+            if (File.Exists(settingsFilePath))
             {
                 try
                 {
-                    var json = File.ReadAllText("settings.json");
+                    var json = File.ReadAllText(settingsFilePath);
                     var ret1 = JsonConvert.DeserializeObject<EQToolSettings>(json);
                     if (ret1 != null)
                     {
@@ -196,7 +197,7 @@ namespace EQTool.Services
 #endif
                 lock (filelock)
                 {
-                    File.WriteAllText("settings.json", txt);
+                    File.WriteAllText(settingsFilePath, txt);
                 }
             }
             catch (Exception)

--- a/EQTool/Services/KnownDirectories.cs
+++ b/EQTool/Services/KnownDirectories.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+using System.IO;
+
+namespace EQTool.Services
+{
+    public static class KnownDirectories
+    {
+        public static string GetExecutableDirectory()
+        {
+            var exeFilePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+            if (string.IsNullOrWhiteSpace(exeFilePath))
+            {
+                // This directory will be incorrect if the user is launching from a batch file or other external process, but it's better than nothing.
+                return Directory.GetCurrentDirectory();
+            }
+
+            return Path.GetDirectoryName(exeFilePath) ?? Directory.GetCurrentDirectory();
+        }
+    }
+}

--- a/EQTool/Services/Map/MapLoad.cs
+++ b/EQTool/Services/Map/MapLoad.cs
@@ -30,7 +30,7 @@ namespace EQTool.Services.Map
                 zone = "freportw";
             }
             var lines = new List<string>();
-            var checkformanualmaps = System.IO.Directory.GetCurrentDirectory() + "/maps";
+            var checkformanualmaps = KnownDirectories.GetExecutableDirectory() + "/maps";
 
             if (System.IO.Directory.Exists(checkformanualmaps))
             {
@@ -47,7 +47,7 @@ namespace EQTool.Services.Map
                 }
             }
             CleanCachedMaps(false);
-            checkformanualmaps = System.IO.Directory.GetCurrentDirectory() + $"/{CurrentMapVersion}";
+            checkformanualmaps = KnownDirectories.GetExecutableDirectory() + $"/{CurrentMapVersion}";
             if (System.IO.File.Exists(checkformanualmaps + "/" + zone + ".bin"))
             {
                 try
@@ -100,7 +100,7 @@ namespace EQTool.Services.Map
 
         public static void CleanCachedMaps(bool deleteAll)
         {
-            var oldcachedmaps = Directory.GetDirectories(System.IO.Directory.GetCurrentDirectory(), "cachedmaps*");
+            var oldcachedmaps = Directory.GetDirectories(KnownDirectories.GetExecutableDirectory(), "cachedmaps*");
 
             foreach (var item in oldcachedmaps)
             {

--- a/EQTool/Services/Spells/ParseSpells_spells_us.cs
+++ b/EQTool/Services/Spells/ParseSpells_spells_us.cs
@@ -177,7 +177,7 @@ namespace EQTool.Services
             var spellsfile = new FileInfo(settings.DefaultEqDirectory + spellfile);
             if (spellsfile.Exists)
             {
-                var spellfilename = $"SpellCache{servers}_1";
+                var spellfilename = Path.Combine(KnownDirectories.GetExecutableDirectory(), $"SpellCache{servers}_1");
                 if (!isdebug)
                 {
                     spellfilename = new string(spellfilename.Where(a => char.IsLetterOrDigit(a)).ToArray()) + ".bin";
@@ -404,8 +404,11 @@ namespace EQTool.Services
                 Debug.Write($"Took {stopwatch.ElapsedMilliseconds}ms to build spells");
                 try
                 {
-                    var filetodelete = Directory.GetFiles(Directory.GetCurrentDirectory(), "SpellCache*", SearchOption.TopDirectoryOnly).FirstOrDefault();
-                    File.Delete(filetodelete);
+                    var filetodelete = Directory.GetFiles(KnownDirectories.GetExecutableDirectory(), "SpellCache*", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                    if (filetodelete != null)
+                    {
+                        File.Delete(filetodelete);
+                    }
                 }
                 catch (Exception)
                 {

--- a/EQTool/Services/UpdateService.cs
+++ b/EQTool/Services/UpdateService.cs
@@ -72,7 +72,7 @@ namespace EQTool.Services
             {
                 if (parameter.Contains("ping"))
                 {
-                    var sourcedirectory = System.IO.Directory.GetCurrentDirectory();
+                    var sourcedirectory = KnownDirectories.GetExecutableDirectory();
                     var parentidirectory = Directory.GetParent(sourcedirectory).FullName;
                     CopyFilesRecursively(sourcedirectory, parentidirectory);
                     var path = Path.Combine(parentidirectory, programName);
@@ -161,25 +161,25 @@ namespace EQTool.Services
                     if (filename.EndsWith(".zip"))
                     {
                         File.WriteAllBytes("EqTool.zip", fileBytes);
-                        ZipFile.ExtractToDirectory("EqTool.zip", System.IO.Directory.GetCurrentDirectory() + "/NewVersion");
+                        ZipFile.ExtractToDirectory("EqTool.zip", KnownDirectories.GetExecutableDirectory() + "/NewVersion");
                     }
                     else
                     {
-                        _ = System.IO.Directory.CreateDirectory(System.IO.Directory.GetCurrentDirectory() + "/NewVersion");
-                        File.WriteAllBytes(System.IO.Directory.GetCurrentDirectory() + "/NewVersion/" + filename, fileBytes);
+                        _ = System.IO.Directory.CreateDirectory(KnownDirectories.GetExecutableDirectory() + "/NewVersion");
+                        File.WriteAllBytes(KnownDirectories.GetExecutableDirectory() + "/NewVersion/" + filename, fileBytes);
                     }
                     loginMiddlemand?.StopListening();
                     appDispatcher?.DispatchUI(() =>
                     {
                         System.Windows.Application.Current.Shutdown();
                     });
-                    var path = System.IO.Directory.GetCurrentDirectory() + $"/NewVersion/{programName}";
+                    var path = KnownDirectories.GetExecutableDirectory() + $"/NewVersion/{programName}";
                     _ = System.Diagnostics.Process.Start(new ProcessStartInfo
                     {
                         FileName = path,
                         Arguments = "ping",
                         UseShellExecute = true,
-                        WorkingDirectory = System.IO.Directory.GetCurrentDirectory() + "/NewVersion/"
+                        WorkingDirectory = KnownDirectories.GetExecutableDirectory() + "/NewVersion/"
                     });
                 }
             }

--- a/EQTool/ViewModels/SettingsWindowViewModel.cs
+++ b/EQTool/ViewModels/SettingsWindowViewModel.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows;
+using EQTool.Services;
 
 namespace EQTool.ViewModels
 {
@@ -308,8 +309,6 @@ namespace EQTool.ViewModels
                 OnPropertyChanged();
             }
         }
-
-        public string CurrentWorkingDirectory { get; } = System.IO.Directory.GetCurrentDirectory();
 
         private string _GroupLeaderName = "None";
         public string GroupLeaderName

--- a/EQtoolsTests/DI.cs
+++ b/EQtoolsTests/DI.cs
@@ -91,7 +91,7 @@ namespace EQtoolsTests
 
             var b = builder.Build();
             var settings = b.Resolve<EQTool.Models.EQToolSettings>();
-            settings.DefaultEqDirectory = Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName;
+            settings.DefaultEqDirectory = Directory.GetParent(KnownDirectories.GetExecutableDirectory()).Parent.FullName;
             return b;
         }
     }

--- a/EQtoolsTests/FileReaderTests.cs
+++ b/EQtoolsTests/FileReaderTests.cs
@@ -12,7 +12,7 @@ namespace EQtoolsTests
     {
         private readonly IFileReader fileReader;
         private readonly LogEvents logEvents;
-        private readonly string FilePath = Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName, "LogFiles");
+        private readonly string FilePath = Path.Combine(Directory.GetParent(KnownDirectories.GetExecutableDirectory()).Parent.FullName, "LogFiles");
 
         public FileReaderTests()
         {


### PR DESCRIPTION
I like to launch Gina, Gamparse, and EQTool all from a batch file that launches all 3 at once. I noticed that EQTool behaved very strangely when doing this. It would place the settings.json, cachedmaps, and SpellsCache files or directories next to my batch file instead of in the directory of EQTool. This is not something I've ever really seen happen in an application before so I decided to look and see what the problem was.

Directory.CurrentDirectory() was the culprit, so I've modified all code that was doing these lookups (or lines that provided no directory at all) to actually use the assembly's directory instead of the directory that it the process was launched from. As far as I can tell I've caught every relevant file reading/writing code but let me know if you think I've missed something.

For the vast majority of users this change should essentially be a nothingburger. Anyone who was launching the tool via a batch file would need to move their files to the root directory to keep operating as normal.