### PR TITLE
Work around wine compatibility issue.

### DIFF
--- a/EQTool/App.xaml.cs
+++ b/EQTool/App.xaml.cs
@@ -316,29 +316,71 @@ namespace EQTool
             else
             {
                 ToggleMenuButtons(true);
+                if (!EQToolSettings.SettingsWindowState.Closed)
+                {
+                    try
+                    {
+                        OpenSettingsWindow();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to open SettingsWindow: {ex}");
+                    }
+                }
                 if (!EQToolSettings.SpellWindowState.Closed)
                 {
-                    OpenSpellsWindow();
+                    try
+                    {
+                        OpenSpellsWindow();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to open SpellWindow: {ex}");
+                    }
                 }
                 if (!EQToolSettings.DpsWindowState.Closed)
                 {
-                    OpenDPSWindow();
+                    try
+                    {
+                        OpenDPSWindow();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to open DPSWindow: {ex}");
+                    }
                 }
                 if (!EQToolSettings.MapWindowState.Closed)
                 {
-                    OpenMapWindow();
-                }
-                if (!EQToolSettings.MobWindowState.Closed)
-                {
-                    OpenMobInfoWindow();
+                    try
+                    {
+                        OpenMapWindow();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to open MapWindow: {ex}");
+                    }
                 }
                 if (!EQToolSettings.OverlayWindowState.Closed)
                 {
-                    OpenOverLayWindow();
+                    try
+                    {
+                        OpenOverLayWindow();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to open OverlayWindow: {ex}");
+                    }
                 }
-                if (!EQToolSettings.SettingsWindowState.Closed)
+                if (!EQToolSettings.MobWindowState.Closed)
                 {
-                    OpenSettingsWindow();
+                    try
+                    {
+                        OpenMobInfoWindow();
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Failed to open MobInfoWindow: {ex}");
+                    }
                 }
             }
             


### PR DESCRIPTION
Affected platform: Ubuntu 24 via Wine

Triggers are failing to countdown. After investigation, I determined it is because a bug in Wine's WPF text rendering system that causes the MobInfo window to fail to load.

The "fix" here is to gracefully skip any windows that fail to load. This allows the triggers to work even though mobinfo fails. I can imagine this getting fixed in a later version of wine, so it's possible it might start magically working in the future.

In the meantime: known issue MobInfo fails to load in linux due to a bug _probably_ in wine.