### PR TITLE
Misc Refactors/Tweaks from Beta

### DIFF
--- a/EQTool/DI.cs
+++ b/EQTool/DI.cs
@@ -41,32 +41,35 @@ namespace EQTool
             {
                 return a.Resolve<Services.EQToolSettingsLoad>().Load();
             }).AsSelf().SingleInstance();
+            
+            _ = builder.RegisterType<Models.SignalrPlayerHub>().SingleInstance();
+            _ = builder.RegisterType<Models.EQSpells>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Models.SessionPlayerDamage>().AsSelf().SingleInstance();
+            
             _ = builder.RegisterType<Services.AppDispatcher>().As<Services.IAppDispatcher>().SingleInstance();
             _ = builder.RegisterType<Services.SpellIcons>().AsSelf().SingleInstance();
             _ = builder.RegisterType<Services.ParseSpells_spells_us>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Services.PlayerTrackerService>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Services.ZoneActivityTrackingService>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Services.TimersService>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Services.SettingsTestRunOverlay>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Services.LoggingService>().AsSelf().SingleInstance();
+            _ = builder.RegisterType<Services.LogParser>().AsSelf().SingleInstance();
+            
             _ = builder.RegisterType<ViewModels.SettingsWindowViewModel>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.MobInfoComponents.PetViewModel>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.MobInfoComponents.MobInfoViewModel>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.MobInfoComponents.MobInfoManagementViewModel>().AsSelf().SingleInstance();
-
-            _ = builder.RegisterType<Models.EQSpells>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.ActivePlayer>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.SpellWindowViewModel>().AsSelf().SingleInstance();
-            _ = builder.RegisterType<Services.LogParser>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.DPSWindowViewModel>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ViewModels.ZoneViewModel>().AsSelf().SingleInstance();
-            _ = builder.RegisterType<Models.SessionPlayerDamage>().AsSelf().SingleInstance();
-            _ = builder.RegisterType<Services.LoggingService>().AsSelf().SingleInstance();
+            
             _ = builder.RegisterType<FightHistory>().AsSelf().SingleInstance();
             _ = builder.RegisterType<SpellDurations>().AsSelf().SingleInstance();
             _ = builder.RegisterType<ConsoleViewModel>().AsSelf().SingleInstance();
             _ = builder.RegisterType<DebugOutput>().AsSelf().SingleInstance();
 
-            _ = builder.RegisterType<Services.PlayerTrackerService>().AsSelf().SingleInstance();
-            _ = builder.RegisterType<Services.ZoneActivityTrackingService>().AsSelf().SingleInstance();
-            _ = builder.RegisterType<Services.TimersService>().AsSelf().SingleInstance();
-            _ = builder.RegisterType<Models.SignalrPlayerHub>().SingleInstance();
-            _ = builder.RegisterType<Services.SettingsTestRunOverlay>().AsSelf().SingleInstance();
             _ = builder.RegisterType<TextToSpeach>().As<ITextToSpeach>().SingleInstance();
             _ = builder.RegisterType<UIRunner>().AsSelf().SingleInstance();
             _ = builder.RegisterType<UpdateRunner>().AsSelf().SingleInstance();

--- a/EQTool/Services/AppDispatcher.cs
+++ b/EQTool/Services/AppDispatcher.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EQTool.Services
 {
     public interface IAppDispatcher
     {
         void DispatchUI(Action action);
+        void DebounceToUI(ref CancellationTokenSource debounceCancellationSource, int delay, Action action);
+        void DebounceToUI(ref CancellationTokenSource debounceCancellationSource, int delay, Action action, Func<bool> shouldCancel);
     }
 
     public class AppDispatcher : IAppDispatcher
@@ -32,6 +35,24 @@ namespace EQTool.Services
             {
 
             }
+        }
+
+        public void DebounceToUI(ref CancellationTokenSource debounceCancellationSource, int delay, Action action) => DebounceToUI(ref debounceCancellationSource, delay, action, () => false);
+        public void DebounceToUI(ref CancellationTokenSource debounceCancellationSource, int delay, Action action, Func<bool> shouldCancel)
+        {
+            debounceCancellationSource?.Cancel();
+            debounceCancellationSource = new CancellationTokenSource();
+            var debounceToken = debounceCancellationSource.Token;
+            
+            Task.Run(async () =>
+            {
+                await Task.Delay(delay, debounceToken);
+                
+                if (debounceToken.IsCancellationRequested || shouldCancel())
+                    return;
+
+                DispatchUI(() => action());
+            }, debounceToken);
         }
     }
 }

--- a/EQTool/Services/Handlers/SpellHandlerService.cs
+++ b/EQTool/Services/Handlers/SpellHandlerService.cs
@@ -127,6 +127,9 @@ namespace EQTool.Services.Handlers
 
         private void AddCooldownTimerIfNecessary(Spell spell, string casterName, string target, int delayOffset)
         {
+            if (spell.name.EndsWith("Recourse", StringComparison.OrdinalIgnoreCase))    // Recourse effects tend to mirror their counterpart and are already handled elsewhere.
+                return;
+            
             var spellName = spell.name;
             var cooldownRecipient = TargetOnlyIfUnknownCaster(casterName, target);
             var cooldownRecipientClass = playerTrackerService.GetPlayer(cooldownRecipient)?.PlayerClass;

--- a/EQTool/Services/PlayerTrackerService.cs
+++ b/EQTool/Services/PlayerTrackerService.cs
@@ -121,9 +121,9 @@ namespace EQTool.Services
             }
             appDispatcher.DispatchUI(() =>
             {
-                var spellsMissingClasses = spellWindowViewModel
-                    .SpellList.Where(x => x.SpellViewModelType == SpellViewModelType.Spell)
-                    .Where(spell => !spell.Target.StartsWith(" "))
+                var spellsMissingClasses = spellWindowViewModel.SpellList
+                    .OfType<SpellViewModel>()
+                    .Where(spell => spell.IsPlayerTarget)
                     .ToList();
                 var missingPlayerNames = spellsMissingClasses.Select(a => a.Target).Distinct().ToList();
                 if (missingPlayerNames.Any())

--- a/EQTool/Services/SavePlayerStateService.cs
+++ b/EQTool/Services/SavePlayerStateService.cs
@@ -37,7 +37,7 @@ namespace EQTool.Services
                     {
                         var before = activePlayer.Player.YouSpells ?? new List<YouSpells>();
                         activePlayer.Player.YouSpells = spellWindowViewModel.SpellList.OfType<SpellViewModel>()
-                            .Where(x => x.CastOnYou(activePlayer.Player))
+                            .Where(x => x.CastOnYou())
                             .Select(a => new YouSpells
                             {
                                 Name = a.Id,

--- a/EQTool/UI/BaseSaveStateWindow.cs
+++ b/EQTool/UI/BaseSaveStateWindow.cs
@@ -226,40 +226,12 @@ namespace EQTool.UI
         
         protected void HoverZone_MouseEnter(object sender, MouseEventArgs e)
         {
-            hoverDebounceTs?.Cancel();
-            hoverDebounceTs = new CancellationTokenSource();
-            var debounceToken = hoverDebounceTs.Token;
-
-            Task.Run(async () =>
-            {
-                await Task.Delay(200, debounceToken);
-                if (!debounceToken.IsCancellationRequested)
-                {
-                    appDispatcher.DispatchUI(() =>
-                    {
-                        baseViewModel.IsMouseOverTitleArea = true;
-                    });
-                }
-            }, debounceToken);
+            appDispatcher.DebounceToUI(ref hoverDebounceTs, 250, () => baseViewModel.IsMouseOverTitleArea = true);
         }
 
         protected void HoverZone_MouseLeave(object sender, MouseEventArgs e)
         {
-            hoverDebounceTs?.Cancel();
-            hoverDebounceTs = new CancellationTokenSource();
-            var debounceToken = hoverDebounceTs.Token;
-
-            Task.Run(async () =>
-            {
-                await Task.Delay(200, debounceToken);
-                appDispatcher.DispatchUI(() =>
-                {
-                    if (!debounceToken.IsCancellationRequested)
-                    {
-                        baseViewModel.IsMouseOverTitleArea = false;
-                    }
-                });
-            }, debounceToken);
+            appDispatcher.DebounceToUI(ref hoverDebounceTs, 250, () => baseViewModel.IsMouseOverTitleArea = false);
         }
         
         public void UpdateShowInTaskbar()

--- a/EQTool/UI/SettingsComponents/SettingsGeneral.xaml.cs
+++ b/EQTool/UI/SettingsComponents/SettingsGeneral.xaml.cs
@@ -276,11 +276,11 @@ namespace EQTool.UI.SettingsComponents
                 new CastTest { Spell = spells.AllSpells["Visions of Grandeur"], CasterName = EQSpells.SpaceYou, TargetName = "Aasgard" },
                 new CastTest { Spell = spells.AllSpells["Defensive Discipline"], CasterName = "Aasgard", TargetName = "Aasgard"},
 
-                new CastTest { Spell = spells.AllSpells["Theft of Thought"], CasterName = EQSpells.SpaceYou, TargetName = "a bad guy" },
-                new CastTest { Spell = spells.AllSpells["Mana Sieve"], CasterName = EQSpells.SpaceYou, TargetName = "a bad guy"},
-                new CastTest { Spell = spells.AllSpells["Mana Sieve"], CasterName = "SomeOtherEnchanter", TargetName = "a bad guy"},
+                new CastTest { Spell = spells.AllSpells["Theft of Thought"], CasterName = EQSpells.SpaceYou, TargetName = "a geonid shaman" },
+                new CastTest { Spell = spells.AllSpells["Mana Sieve"], CasterName = EQSpells.SpaceYou, TargetName = "a geonid shaman"},
+                new CastTest { Spell = spells.AllSpells["Mana Sieve"], CasterName = "SomeOtherEnchanter", TargetName = "a geonid shaman"},
                 new CastTest { Spell = spells.AllSpells["Harvest"], TargetName = "DrWizardGuy"},
-                new CastTest { Spell = spells.AllSpells["Quivering Veil of Xarn"], CasterName = "NecroManGuy", TargetName = "NecroManGuy"},
+                new CastTest { Spell = spells.AllSpells["Quivering Veil of Xarn"], CasterName = "Necromanguy", TargetName = "Necromanguy"},
 
                 new CastTest { Spell = spells.AllSpells["LowerElement"], TargetName = "Tunare"},
                 new CastTest { Spell = spells.AllSpells["LowerElement"], TargetName = "Tunare"},

--- a/EQTool/ViewModels/ActivePlayerInfo.cs
+++ b/EQTool/ViewModels/ActivePlayerInfo.cs
@@ -205,24 +205,11 @@ namespace EQTool.ViewModels
 
         public void ClearUserCastingSpellLater(Spell spell, DateTime? castedOn)
         {
-            aoeDebounceTs?.Cancel();
-            aoeDebounceTs = new CancellationTokenSource();
-            var debounceToken = aoeDebounceTs.Token;
-
-            Task.Run(async () =>
+            appDispatcher.DebounceToUI(ref aoeDebounceTs, 200, ClearUserCastingSpellImmediately, shouldCancel: () =>
             {
-                await Task.Delay(200, debounceToken);
                 var castTimeDiff = Math.Abs(((castedOn ?? DateTime.MaxValue) - (UserCastSpellDateTime ?? DateTime.MinValue)).TotalMilliseconds);
-                if (debounceToken.IsCancellationRequested || UserCastingSpell != spell || castTimeDiff > 200)
-                {
-                    return;
-                }
-
-                appDispatcher.DispatchUI(() =>
-                {
-                    ClearUserCastingSpellImmediately();
-                });
-            }, debounceToken);
+                return UserCastingSpell != spell || castTimeDiff > 200;
+            });
         }
 
         public void ClearUserCastingSpellImmediately()

--- a/EQTool/ViewModels/SpellWindow/CounterViewModel.cs
+++ b/EQTool/ViewModels/SpellWindow/CounterViewModel.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Linq;
 using EQTool.Models;
 using EQTool.Services;
-using EQToolShared.Enums;
 
 namespace EQTool.ViewModels.SpellWindow
 {
@@ -35,6 +34,6 @@ namespace EQTool.ViewModels.SpellWindow
         }
         
         private HashSet<string> casters = new HashSet<string>();
-        public override bool CastByYou(PlayerInfo player) => casters.Any(x => x == EQSpells.You || x == EQSpells.SpaceYou || (player != null && x == player.Name));
+        public override bool CastByYou() => casters.Any(x => x == EQSpells.You || x == EQSpells.SpaceYou);
     }
 }

--- a/EQTool/ViewModels/SpellWindow/PersistentViewModel.cs
+++ b/EQTool/ViewModels/SpellWindow/PersistentViewModel.cs
@@ -58,20 +58,19 @@ namespace EQTool.ViewModels.SpellWindow
 
         public virtual string DisplayName => IsCategorizeById ? Target : Id;
         public virtual string DisplayGroup => IsCategorizeById ? Id : Target;
+        public virtual string ByIdDisplayGroup() => Id.TrimEnd(" Cooldown");   // For cooldowns, we want it to be grouped with the spell itself.
+        
         public virtual string GroupSorting
         {
             get
             {
                 var groupName = DisplayGroup;
-                if (groupName.StartsWith(" ") && groupName != EQSpells.SpaceYou)
-                {
+                if (!IsPlayerTarget)
                     return SortingPrefixes.Primary + groupName;
-                }
                 if (groupName == EQSpells.SpaceYou)
-                {
                     return SortingPrefixes.Secondary + groupName;
-                }
-                return SortingPrefixes.Tertiary + groupName;
+                
+                return SortingPrefixes.Quaternary + groupName;
             }
         }
         

--- a/EQTool/ViewModels/SpellWindow/SpellViewModel.cs
+++ b/EQTool/ViewModels/SpellWindow/SpellViewModel.cs
@@ -2,7 +2,6 @@
 using EQToolShared.Enums;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Windows.Media;
 using EQTool.Services;
 
@@ -27,21 +26,13 @@ namespace EQTool.ViewModels.SpellWindow
             {
                 _BenefitDetrimentFlag = value;
                 if (_BenefitDetrimentFlag == SpellBenefitDetriment.Beneficial)
-                {
                     ProgressBarColor = Brushes.MediumAquamarine;
-                }
                 else if (_BenefitDetrimentFlag == SpellBenefitDetriment.Detrimental)
-                {
                     ProgressBarColor = Brushes.OrangeRed;
-                }
                 else if (_BenefitDetrimentFlag == SpellBenefitDetriment.Cooldown)
-                {
                     ProgressBarColor = Brushes.SkyBlue;
-                }
                 else
-                {
                     ProgressBarColor = Brushes.DarkSeaGreen;
-                }
             }
         }
         
@@ -50,29 +41,19 @@ namespace EQTool.ViewModels.SpellWindow
             get
             {
                 var groupName = DisplayGroup;
-                if ((groupName.StartsWith(" ") && groupName != EQSpells.SpaceYou) || (IsCategorizeById && BenefitDetriment == SpellBenefitDetriment.Detrimental))
-                {
+                if (!IsPlayerTarget || (IsCategorizeById && BenefitDetriment == SpellBenefitDetriment.Detrimental))
                     return SortingPrefixes.Primary + groupName;
-                }
                 if (groupName == EQSpells.SpaceYou)
-                {
                     return SortingPrefixes.Secondary + groupName;
-                }
-                if (IsCategorizeById && BenefitDetriment == SpellBenefitDetriment.Cooldown)
-                {
+                if (IsCategorizeById && BenefitDetriment != SpellBenefitDetriment.Detrimental)
                     return SortingPrefixes.Tertiary + groupName;
-                }
-                if (IsCategorizeById && BenefitDetriment == SpellBenefitDetriment.Beneficial)
-                {
-                    return SortingPrefixes.Quaternary + groupName;
-                }
                 
-                return SortingPrefixes.Tertiary + groupName;
+                return SortingPrefixes.Quaternary + groupName;
             }
         }
         
-        public bool CastOnYou(PlayerInfo player) => Target == EQSpells.You || Target == EQSpells.SpaceYou || (player != null && Target == player.Name);
-        public virtual bool CastByYou(PlayerInfo player) => Caster == EQSpells.You || Caster == EQSpells.SpaceYou || (player != null && Caster == player.Name);
-        public bool CastByYourClass(PlayerInfo player) => CastByYou(player) || (player.PlayerClass.HasValue && Classes.ContainsKey(player.PlayerClass.Value));
+        public bool CastOnYou() => Target == EQSpells.You || Target == EQSpells.SpaceYou;
+        public virtual bool CastByYou() => Caster == EQSpells.You || Caster == EQSpells.SpaceYou || (SpellType == SpellType.Self && CastOnYou());
+        public bool CastByYourClass(PlayerInfo player) => player?.PlayerClass != null && Classes.ContainsKey(player.PlayerClass.Value) || CastByYou();
     }
 }

--- a/EQTool/ViewModels/SpellWindowViewModel.cs
+++ b/EQTool/ViewModels/SpellWindowViewModel.cs
@@ -118,7 +118,7 @@ namespace EQTool.ViewModels
         {
             appDispatcher.DispatchUI(() =>
             {
-                var itemsToRemove = SpellList.Where(s => s is SpellViewModel vm && vm.CastOnYou(activePlayer.Player)).ToList();
+                var itemsToRemove = SpellList.Where(s => s is SpellViewModel vm && vm.CastOnYou()).ToList();
                 foreach (var item in itemsToRemove)
                     _ = SpellList.Remove(item);
             });
@@ -130,7 +130,7 @@ namespace EQTool.ViewModels
             {
                 var nonDisciplinCooldowns = SpellList
                     .Where(s => s is SpellViewModel vm
-                        && vm.CastOnYou(activePlayer.Player)
+                        && vm.CastOnYou()
                         && !(vm.BenefitDetriment == SpellBenefitDetriment.Cooldown && s.Id.Contains("Discipline", StringComparison.OrdinalIgnoreCase)))
                     .ToList();
                 
@@ -407,7 +407,7 @@ namespace EQTool.ViewModels
         {
             if (RaidModeEnabled)
             {
-                if (s.CastByYou(player) || s.CastOnYou(player) || s.Target == CustomTimer.CustomerTime)
+                if (s.CastByYou() || s.CastOnYou() || s.Target == CustomTimer.CustomerTime)
                 {
                     return false;
                 }
@@ -427,9 +427,9 @@ namespace EQTool.ViewModels
             
             switch (settings.SpellsFilter)
             {
-                case SpellsFilterType.CastOnYou when !s.CastOnYou(player):
-                case SpellsFilterType.CastByYou when !s.CastByYou(player):
-                case SpellsFilterType.CastByOrOnYou when !(s.CastOnYou(player) || s.CastByYou(player)):
+                case SpellsFilterType.CastOnYou when !s.CastOnYou():
+                case SpellsFilterType.CastByYou when !s.CastByYou():
+                case SpellsFilterType.CastByOrOnYou when !(s.CastOnYou() || s.CastByYou()):
                     return true;
                 case SpellsFilterType.ByClass:
                     return !IsClassSpellAllowed(s.Classes, player.ShowSpellsForClasses);
@@ -454,7 +454,7 @@ namespace EQTool.ViewModels
             {
                 var spellsToRemove = SpellList
                     .OfType<SpellViewModel>()
-                    .Where(a => !a.CastOnYou(activePlayer.Player))
+                    .Where(a => !a.CastOnYou())
                     .ToList();
                 
                 foreach (var spell in spellsToRemove)
@@ -473,7 +473,7 @@ namespace EQTool.ViewModels
             {
                 var spellToRemove = SpellList
                     .OfType<SpellViewModel>()
-                    .Where(a => !a.CastByYou(activePlayer.Player))
+                    .Where(a => !a.CastByYou())
                     .ToList();
                 
                 foreach (var spell in spellToRemove)
@@ -606,7 +606,7 @@ namespace EQTool.ViewModels
             {
                 var spells = SpellList
                     .OfType<SpellViewModel>()
-                    .Where(spell => string.Equals(spell.Id, possibleSpell, StringComparison.OrdinalIgnoreCase) && !spell.CastOnYou(activePlayer.Player))
+                    .Where(spell => string.Equals(spell.Id, possibleSpell, StringComparison.OrdinalIgnoreCase) && !spell.CastOnYou())
                     .ToList();
                 
                 if (spells.Count == 1)
@@ -647,7 +647,7 @@ namespace EQTool.ViewModels
             appDispatcher.DispatchUI(() =>
             {
                 var spells = SpellList.OfType<SpellViewModel>()
-                    .Where(spell => possibleSpellNames.Any(name => spell.CastOnYou(activePlayer.Player) && string.Equals(spell.Id, name, StringComparison.OrdinalIgnoreCase)))
+                    .Where(spell => possibleSpellNames.Any(name => spell.CastOnYou() && string.Equals(spell.Id, name, StringComparison.OrdinalIgnoreCase)))
                     .ToList();
                 
                 if (spells.Count == 1)
@@ -667,7 +667,7 @@ namespace EQTool.ViewModels
             appDispatcher.DispatchUI(() =>
             {
                 var spells = SpellList.OfType<SpellViewModel>()
-                    .Where(spell => spell.CastOnYou(activePlayer.Player) && partialSpellNames.Any(name => spell.Id.Contains(name, StringComparison.OrdinalIgnoreCase)))
+                    .Where(spell => spell.CastOnYou() && partialSpellNames.Any(name => spell.Id.Contains(name, StringComparison.OrdinalIgnoreCase)))
                     .ToList();
                 
                 _ = SpellList.Remove(spells.FirstOrDefault());
@@ -796,7 +796,7 @@ namespace EQTool.ViewModels
             }
             else if (groupingType == SpellGroupingType.BySpellExceptYou)
             {
-                spell.IsCategorizeById = !spell.CastOnYou(activePlayer.Player);
+                spell.IsCategorizeById = !spell.CastOnYou();
             }
             // Originally was trying for a "MostConcise" or "Automatic" option here as well, but it was more trouble than it was worth. Maybe later.
         }

--- a/EQtoolsTests/Fakes/AppDispatcherFake.cs
+++ b/EQtoolsTests/Fakes/AppDispatcherFake.cs
@@ -1,5 +1,7 @@
 ﻿using EQTool.Services;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EQtoolsTests.Fakes
 {
@@ -8,6 +10,25 @@ namespace EQtoolsTests.Fakes
         public void DispatchUI(Action action)
         {
             action();
+        }
+
+        // We don't really wanna fake this stuff to be honest. I don't love having this code duplicated but it shouldn't ever change so it should be fine.
+        public void DebounceToUI(ref CancellationTokenSource debounceCancellationSource, int delay, Action action) => DebounceToUI(ref debounceCancellationSource, delay, action, () => false);
+        public void DebounceToUI(ref CancellationTokenSource debounceCancellationSource, int delay, Action action, Func<bool> shouldCancel)
+        {
+            debounceCancellationSource?.Cancel();
+            debounceCancellationSource = new CancellationTokenSource();
+            var debounceToken = debounceCancellationSource.Token;
+            
+            Task.Run(async () =>
+            {
+                await Task.Delay(delay, debounceToken);
+                
+                if (debounceToken.IsCancellationRequested || shouldCancel())
+                    return;
+
+                action();
+            }, debounceToken);
         }
     }
 }


### PR DESCRIPTION
Cruft I'm pulling off of the beta branch so that the beta PR will be less of a nightmare to review.

* Reorganized the DI registrations a little.
* Added a new parse check for "they are protected", flags it as a resist since that's _essentially_ what it is, but may change in the future idk.
* Moved our common debounce code over to the app dispatcher since it's common enough at this point and closely related.
* Excluded recourse effects from cooldowns as they always have one tied to the original spell.
* Removed the activePlayer stuff from CastByYou/CastOnYou checks since it was never really applicable and was limiting for some pieces of code.
* Fixed some .StartsWith(" ") checks to just use the new IsPlayerTarget property.